### PR TITLE
Minimal example of URL validation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+venv*/
+.mypy_cache/

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+pydantic
+typing_extensions

--- a/validate.py
+++ b/validate.py
@@ -1,0 +1,37 @@
+# This isn't how I would maintain/manage python code, but is intended to show 
+# a minimum example of how you could use python to validate `predefined_url.json`
+# Cheers!
+# - ZH
+"""Validate the JSON has valid URLs"""
+
+import json
+from pathlib import Path
+import sys
+# Because I saw you're using 3.10, we use this. If 3.11+, use 'from typing import Self'
+from typing_extensions import Self
+from pydantic import BaseModel, HttpUrl
+
+class PredefinedUrl(BaseModel):
+    """Predefined URL Entry"""
+    url: HttpUrl
+
+
+
+    @classmethod
+    def from_file(cls, file: Path) -> list[Self]:
+        """Load a list of predefined URLs from file"""
+        with file.open("r", encoding="utf8") as handle:
+            data: list[dict[str, str]] = json.load(handle)
+        return [cls.model_validate(x) for x in data]
+
+def main() -> None:
+    """Program main entry point"""
+    predefined_url = Path(sys.argv[1])
+    if not predefined_url.is_file():
+        raise FileNotFoundError(f"Could not find {predefined_url=}")
+    model = PredefinedUrl.from_file(predefined_url)
+    print(f"Model is valid: {model=}")
+
+
+if __name__ == "__main__": # pragma: no cover
+    main()


### PR DESCRIPTION
In case you wanted to avoid using GHAs for this. I know the point is to make the GHAs work, but it seems like a lot of work for something that can be done with relative ease. I'm sure I missed the point, but when Susan explained what she thinks is happening, I thought "why so many steps?"

And if this is close to the mark, [pydantic](https://docs.pydantic.dev/2.10/) is very extensible in the kinds of checks you can make with it.

E.g,

All you need to do is run `python validate.py ./predefined_url.json`

### Use Case 1: Happy Path
```json
[
    {
        "url": "https://github.com/altera-fpga/agilex7f-nios-ed"
    }
]
```

**Output**

```bash
> python validate.py ./predefined_url.json
Model is valid: model=[PredefinedUrl(url=HttpUrl('https://github.com/altera-fpga/agilex7f-nios-ed'))]
```

### Use Case 2: Invalid URL
```json
[
    {
        "url": "github.com/altera-fpga/agilex7f-nios-ed"
    }
]
```

**Output**

```bash
> python validate.py ./predefined_url.json
Traceback (most recent call last):
  File "C:\code\altera-fpga-settings\validate.py", line 37, in <module>
    main()
  File "C:\code\altera-fpga-settings\validate.py", line 32, in main
    model = PredefinedUrl.from_file(predefined_url)
  File "C:\code\altera-fpga-settings\validate.py", line 25, in from_file
    return [cls.model_validate(x) for x in data]
  File "C:\code\altera-fpga-settings\validate.py", line 25, in <listcomp>
    return [cls.model_validate(x) for x in data]
  File "C:\code\altera-fpga-settings\venv310\lib\site-packages\pydantic\main.py", line 627, in model_validate
    return cls.__pydantic_validator__.validate_python(
pydantic_core._pydantic_core.ValidationError: 1 validation error for PredefinedUrl
url
  Input should be a valid URL, relative URL without a base [type=url_parsing, input_value='github.com/altera-fpga/agilex7f-nios-ed', input_type=str]
    For further information visit https://errors.pydantic.dev/2.10/v/url_parsing
```

### Use Case 3: Invalid input file

```bash
> python validate.py ./predefined_url.jsson
Traceback (most recent call last):
  File "C:\code\altera-fpga-settings\validate.py", line 37, in <module>
    main()
  File "C:\code\altera-fpga-settings\validate.py", line 31, in main
    raise FileNotFoundError(f"Could not find {predefined_url=}")
FileNotFoundError: Could not find predefined_url=WindowsPath('predefined_url.jsson')
```

### Use Case 4: Malformed JSON

```json
[
    {
        "url": "github.com/altera-fpga/agilex7f-nios-ed"
    }

```

```bash
> python .\validate.py ./predefined_url.json
Traceback (most recent call last):
  File "C:\code\altera-fpga-settings\validate.py", line 37, in <module>
    main()
  File "C:\code\altera-fpga-settings\validate.py", line 32, in main
    model = PredefinedUrl.from_file(predefined_url)
  File "C:\code\altera-fpga-settings\validate.py", line 24, in from_file
    data: list[dict[str, str]] = json.load(handle)
  File "c:\python310\lib\json\__init__.py", line 293, in load
    return loads(fp.read(),
  File "c:\python310\lib\json\__init__.py", line 346, in loads
    return _default_decoder.decode(s)
  File "c:\python310\lib\json\decoder.py", line 337, in decode
    obj, end = self.raw_decode(s, idx=_w(s, 0).end())
  File "c:\python310\lib\json\decoder.py", line 353, in raw_decode
    obj, end = self.scan_once(s, idx)
json.decoder.JSONDecodeError: Expecting ',' delimiter: line 8 column 1 (char 74)
```